### PR TITLE
fix: typescript aliases path resolution

### DIFF
--- a/packages/skott/src/modules/walkers/ecmascript/typescript/path-alias.ts
+++ b/packages/skott/src/modules/walkers/ecmascript/typescript/path-alias.ts
@@ -51,7 +51,7 @@ export function resolvePathAlias(
     return aliasWithoutGlob;
   }
 
-  const baseAliasDirname = path.dirname(moduleDeclaration);
+  const [baseAliasDirname] = path.dirname(moduleDeclaration).split(path.sep);
   const baseAlias = aliasLinks.get(baseAliasDirname);
 
   if (baseAlias) {
@@ -75,7 +75,8 @@ export function resolvePathAlias(
 }
 
 export function isTypeScriptPathAlias(moduleDeclaration: string): boolean {
-  if (aliasLinks.has(path.dirname(moduleDeclaration))) {
+  const [baseDirname] = path.dirname(moduleDeclaration).split("/");
+  if (aliasLinks.has(baseDirname)) {
     return true;
   }
 

--- a/packages/skott/test/ecmascript/typescript.spec.ts
+++ b/packages/skott/test/ecmascript/typescript.spec.ts
@@ -313,7 +313,7 @@ describe("When traversing a TypeScript project", () => {
               `,
               "lib.ts": `
                 import app from "app/skott";
-                import s from "shared";
+                import s from "shared/utils/foo";
                 import { script } from "@typescript-eslint/estree-parser";
               `,
               "src/config/json/index.ts": `
@@ -322,7 +322,7 @@ describe("When traversing a TypeScript project", () => {
               "src/core/apps/skott.ts": `
                 export function skottHtml(): string { return "<h1>skott</h1>"; }
               `,
-              "src/core/shared/index.ts": `
+              "src/core/shared/utils/foo/index.ts": `
                 export function shared(): string {}
               `,
               "tsconfig.json": JSON.stringify(tsConfig)
@@ -343,7 +343,7 @@ describe("When traversing a TypeScript project", () => {
               "lib.ts": {
                 adjacentTo: [
                   "src/core/apps/skott.ts",
-                  "src/core/shared/index.ts"
+                  "src/core/shared/utils/foo/index.ts"
                 ],
                 id: "lib.ts",
                 body: {
@@ -361,9 +361,9 @@ describe("When traversing a TypeScript project", () => {
                 id: "src/core/apps/skott.ts",
                 body: fakeNodeBody
               },
-              "src/core/shared/index.ts": {
+              "src/core/shared/utils/foo/index.ts": {
                 adjacentTo: [],
-                id: "src/core/shared/index.ts",
+                id: "src/core/shared/utils/foo/index.ts",
                 body: fakeNodeBody
               }
             });


### PR DESCRIPTION
Typescript path resolution was fixed for the paths which contain nested directories, e.g:
import {foo} from "shared/utils/foo"

TS config alias:
"shared/*": ["core/shared/*"]

path.dirname returns shared/utils for the example import part, hence it wasn't properly resolved and was marked as "third-party" module.